### PR TITLE
Lower min sdk for the library to 21

### DIFF
--- a/geo-compose/build.gradle.kts
+++ b/geo-compose/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     namespace = "dev.icerock.moko.geo.compose"
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
     }
 
     compileOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 
 moko.android.targetSdk=34
 moko.android.compileSdk=34
-moko.android.minSdk=24
+moko.android.minSdk=21
 
 moko.publish.name=MOKO geo
 moko.publish.description=Geolocation access for mobile (android & ios) Kotlin Multiplatform development

--- a/sample/android-app/build.gradle.kts
+++ b/sample/android-app/build.gradle.kts
@@ -15,6 +15,8 @@ android {
 
         versionCode = 1
         versionName = "0.1.0"
+
+        minSdk = 24
     }
 
     compileOptions {


### PR DESCRIPTION
In https://github.com/burnoo/moko-geo/commit/8d33a8aa2c82b41c6f3c3dbef579246ce3d26d1a I've bumped min sdk to 24, due to errors with compiling sample app. It turns out that I can lower min sdk for the library and just bump min sdk for the sample.